### PR TITLE
Fix bug in "errorMessagesFor" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ const result = {
 }
 
 errorMessagesFor(result.inputErrors, 'email') === null
-errorMessagesFor(result.environmentErrors, 'host').message === 'Must not be empty'
+errorMessagesFor(result.environmentErrors, 'host')[0] === 'Must not be empty'
 ```
 #### errorMessagesForSchema
 Given a array of `SchemaError` be it from `inputErrors` or `environmentErrors` and a Zod Schema, it returns an object with a list of error messages for each key in the schema shape.


### PR DESCRIPTION
This example of the `errorMessagesFor` function returns a string array, but the example in the README was trying to access an unexisting `message` property on the result instead of indexing that array.