### PR TITLE
Correct return type of errorMessageFor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ const result = {
   environmentErrors: [{ message: 'Must not be empty', path: ['host'] }, { message: 'Must be a fully qualified domain', path: ['host'] }]
 }
 
-errorMessagesFor(result.inputErrors, 'email') === null
+errorMessagesFor(result.inputErrors, 'email') // will be an empty array: []
 errorMessagesFor(result.environmentErrors, 'host').message === 'Must not be empty'
 ```
 #### errorMessagesForSchema


### PR DESCRIPTION
When there are no messages in the `errorMessageFor` function result, it's not correct to say that the result will be `null` like in the example.  The correct return type for that example is an empty array.