### PR TITLE
Type tests

### DIFF
--- a/src/domain-function.test.ts
+++ b/src/domain-function.test.ts
@@ -1259,6 +1259,11 @@ describe('trace', () => {
     const c = trace<unknown>((context) => {
       contextFromFunctionA = context
     })(a)
+    {
+      // TODO: fix this
+      // @ts-ignore
+      type test = Expect<Equal<typeof c, DomainFunction<number>>>
+    }
 
     assertEquals(await fromSuccess(c)({ id: 1 }), 2)
     assertEquals(contextFromFunctionA, {

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -307,7 +307,7 @@ function trace(
   }: {
     input: unknown
     environment: unknown
-    result: unknown
+    result: Result<unknown>
   }) => void,
 ): <T>(fn: DomainFunction<T>) => DomainFunction<T> {
   return (fn) => async (input, environment) => {

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -15,6 +15,7 @@ import type {
   Result,
   TupleToUnion,
   UnpackData,
+  UnpackResult,
 } from './types.ts'
 import type { Last, List, ListToResultData } from './types.ts'
 import type { SuccessResult } from './types.ts'
@@ -22,7 +23,7 @@ import type { SuccessResult } from './types.ts'
 function makeDomainFunction<
   Schema extends z.ZodTypeAny,
   EnvSchema extends z.ZodTypeAny,
->(inputSchema?: Schema , environmentSchema?: EnvSchema) {
+>(inputSchema?: Schema, environmentSchema?: EnvSchema) {
   return function <Output>(
     handler: (
       input: z.infer<Schema>,
@@ -33,7 +34,7 @@ function makeDomainFunction<
       const envResult = await (
         environmentSchema ?? z.object({})
       ).safeParseAsync(environment)
-        const result = await (inputSchema ?? z.undefined()).safeParseAsync(input)
+      const result = await (inputSchema ?? z.undefined()).safeParseAsync(input)
 
       try {
         if (result.success === true && envResult.success === true) {
@@ -299,20 +300,17 @@ function mapError<O>(
   }
 }
 
-function trace(
-  traceFn: ({
-    input,
-    environment,
-    result,
-  }: {
-    input: unknown
-    environment: unknown
-    result: Result<unknown>
-  }) => void,
+type TraceData<T> = {
+  input: unknown
+  environment: unknown
+  result: T
+}
+function trace<D extends DomainFunction = DomainFunction<unknown>>(
+  traceFn: ({ input, environment, result }: TraceData<UnpackResult<D>>) => void,
 ): <T>(fn: DomainFunction<T>) => DomainFunction<T> {
   return (fn) => async (input, environment) => {
     const result = await fn(input, environment)
-    traceFn({ input, environment, result })
+    traceFn({ input, environment, result } as TraceData<UnpackResult<D>>)
     return result
   }
 }

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,94 @@
+// deno-lint-ignore-file ban-ts-comment no-namespace no-unused-vars require-await
+import { makeDomainFunction } from './domain-functions.ts'
+import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
+import { assertEquals } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
+import * as Subject from './types.ts'
+
+type Expect<T extends true> = T
+type Equal<A, B> =
+  // prettier is removing the parens thus worsening readability
+  // prettier-ignore
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false
+
+namespace UnpackData {
+  const result = makeDomainFunction()(async () => ({ name: 'foo' } as const))
+
+  type test = Expect<
+    Equal<Subject.UnpackData<typeof result>, { readonly name: 'foo' }>
+  >
+  type error = Expect<
+    // @ts-expect-error
+    Equal<Subject.UnpackData<typeof result>, { name: string }>
+  >
+}
+
+namespace UnpackResult {
+  const result = makeDomainFunction()(async () => ({ name: 'foo' }))
+
+  type test = Expect<
+    Equal<Subject.UnpackResult<typeof result>, Subject.Result<{ name: string }>>
+  >
+}
+
+namespace UnpackSuccess {
+  const result = makeDomainFunction()(async () => ({ name: 'foo' }))
+
+  type test = Expect<
+    Equal<
+      Subject.UnpackSuccess<typeof result>,
+      Subject.SuccessResult<{ name: string }>
+    >
+  >
+}
+
+namespace MergeObjs {
+  const obj1 = { a: 1, b: 2 } as const
+  const obj2 = {}
+  const obj3 = { c: 3, d: 4 } as const
+
+  type Result = Subject.MergeObjs<[typeof obj1, typeof obj2, typeof obj3]>
+
+  type test1 = Expect<Equal<keyof Result, 'a' | 'b' | 'c' | 'd'>>
+  type test2 = Expect<Equal<Result[keyof Result], 1 | 2 | 3 | 4>>
+}
+
+namespace TupleToUnion {
+  type Result = Subject.TupleToUnion<[1, 2, 3]>
+
+  type test = Expect<Equal<Result, 1 | 2 | 3>>
+}
+
+namespace Last {
+  type test1 = Expect<Equal<Subject.Last<[1, 2, 3]>, 3>>
+  type test2 = Expect<Equal<Subject.Last<[1]>, 1>>
+  type test3 = Expect<Equal<Subject.Last<[]>, never>>
+}
+
+namespace AtLeastOne {
+  type Result = Subject.AtLeastOne<{ a: 1; b: 2 }>
+
+  const test1: Result = { a: 1 }
+  const test2: Result = { b: 2 }
+  const test3: Result = { a: 1, b: 2 }
+  // @ts-expect-error
+  const error1: Result = {}
+  // @ts-expect-error
+  const error2: Result = { a: 1, c: 3 }
+}
+
+namespace ListToResultData {
+  const dfA = makeDomainFunction()(async () => ({ a: 1 } as const))
+  const dfB = makeDomainFunction()(async () => ({ b: 2 } as const))
+
+  type Result = Subject.List.Map<
+    Subject.ListToResultData,
+    [typeof dfA, typeof dfB]
+  >
+
+  type test = Expect<Equal<Result, [{ readonly a: 1 }, { readonly b: 2 }]>>
+}
+
+describe('type tests', () =>
+  it('should have no ts errors', () => assertEquals(true, true)))

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -4,8 +4,8 @@ import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
 import { assertEquals } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
 import * as Subject from './types.ts'
 
-type Expect<T extends true> = T
-type Equal<A, B> =
+export type Expect<T extends true> = T
+export type Equal<A, B> =
   // prettier is removing the parens thus worsening readability
   // prettier-ignore
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,33 @@
+// deno-lint-ignore-file ban-ts-comment no-namespace
+import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
+import { assertEquals } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
+import * as subject from './utils.ts'
+import { Result, SuccessResult } from './types.ts'
+
+type Expect<T extends true> = T
+type Equal<A, B> =
+  // prettier is removing the parens thus worsening readability
+  // prettier-ignore
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false
+
+namespace isListOfSuccess {
+  const results = [
+    {
+      success: true,
+      data: true,
+      errors: [],
+      inputErrors: [],
+      environmentErrors: [],
+    } as Result<boolean>,
+  ]
+  if (!subject.isListOfSuccess(results)) throw new Error('failing test')
+
+  type test = Expect<Equal<typeof results, SuccessResult<boolean>[]>>
+  // @ts-expect-error
+  type error = Expect<Equal<typeof results, Result<boolean>[]>>
+}
+
+describe('util tests', () =>
+  it('should have no ts errors', () => assertEquals(true, true)))

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,15 +2,8 @@
 import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
 import { assertEquals } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
 import * as subject from './utils.ts'
-import { Result, SuccessResult } from './types.ts'
-
-type Expect<T extends true> = T
-type Equal<A, B> =
-  // prettier is removing the parens thus worsening readability
-  // prettier-ignore
-  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
-    ? true
-    : false
+import type { Result, SuccessResult } from './types.ts'
+import type { Equal, Expect } from './types.test.ts'
 
 namespace isListOfSuccess {
   const results = [


### PR DESCRIPTION
## Purpose
Since this is a TS heavy library I think it is time for us to introduce type-level tests and avoid breaking type inference on our releases.

## Tech details
- I added 2 new type utilities to help doing type-level testing: `Expect` and `Equal`
- I started by testing the `types.ts` file using namespaces (to repeat types and consts) as if they were `describe` blocks.
- The files that only have type tests must have a dummy runtime test at the bottom.
- I'm using `// @ts-expect-error` whenever I feel it makes sense to expect something to break
- on the `domain-functions.test` file I'm testing **every** composition inference as we've seen code refactorings that would only mess with one or two inferences

## I caught a type bug 🐞
The newly introduced `trace` function kills the type inference of the composition applied to it.
Any DF given to `trace` will be inferred as `DomainFunction<unknown>`.

That was introduced in favor of typing the `result` of the trace callback.
I'm gonna do a PR on top of this one to return the inference to the composition. It'll kill the inference of the `result` but I think the value of having the composition strongly typed is far superior.