### PR TITLE
🐛 Fix type bug with trace function

### DIFF
--- a/src/domain-function.test.ts
+++ b/src/domain-function.test.ts
@@ -1221,15 +1221,13 @@ describe('trace', () => {
     let contextFromFunctionA: {
       input: unknown
       environment: unknown
-      result: Result<unknown>
+      result: unknown
     } | null = null
 
-    const c = trace<unknown>((context) => {
+    const c = trace((context) => {
       contextFromFunctionA = context
     })(a)
     {
-      // TODO: fix this
-      // @ts-ignore
       type test = ExpectDF<typeof c, number>
     }
 

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -299,20 +299,22 @@ function mapError<O>(
   }
 }
 
-function trace<T>(
-  traceFn: (
-    { input, environment, result }: {
-      input: unknown;
-      environment: unknown;
-      result: Result<T>;
-    },
-  ) => void,
-): (fn: DomainFunction<T>) => DomainFunction<T> {
+function trace(
+  traceFn: ({
+    input,
+    environment,
+    result,
+  }: {
+    input: unknown
+    environment: unknown
+    result: unknown
+  }) => void,
+): <T>(fn: DomainFunction<T>) => DomainFunction<T> {
   return (fn) => async (input, environment) => {
-    const result = await fn(input, environment);
-    traceFn({ input, environment, result });
-    return result;
-  };
+    const result = await fn(input, environment)
+    traceFn({ input, environment, result })
+    return result
+  }
 }
 
 export {


### PR DESCRIPTION
## Purpose
When doing type-level testing (#58) I realized the newly introduced `trace` function kills the type inference of the composition applied to it.
Any DF given to trace will be inferred as DomainFunction<unknown>.

That was introduced in favor of typing the result of the trace callback which kind of defeats the purpose bc neither are being properly inferred unless you give trace a manual type argument.

We might be able to keep both inferences with some TS contortionism which I could not take off the 🎩.

The problem actually seems impossible on the first look, it lies on the API decision:
```ts
const df = makeDomainFunction()(async () => 1)
//    ^? DomainFunction<Number>

const logErrors = trace(({ input, result, output }) => console.log({ input, result, output }))
//                                 ?^ unknown
// the type is unknown and how am I supposed to know what is going to be applied later?

const dfWithLog = logErrors(df)
// Too late to infer the typeof df
```

It seems to be an underlying issue with the chosen order of parameters with the curried API.

## Possible solutions for the current API

What could be done without breaking the API is to manually set the type param:
```ts
type TraceCallback<T> = ({ input: unknown, output: unknown, result: T }) => void

type Trace = <U = unknown>(
  cb: TraceCallback<U>
) => <T>(df: DomainFunction<T>) => DomainFunction<T>

const df = makeDomainFunction()(async () => 1)
//    ^? DomainFunction<Number>

const logErrors = trace<UnpackResult<typeof df>>(
  ({ input, result, output }) => console.log({ input, result, output })
//          ?^ Result<number>
)
```

Or even
```ts
type Trace = <U extends DomainFunction = DomainFunction<unknown>>(
  cb: TraceCallback<UnpackResult<U>>
) => <T>(df: DomainFunction<T>) => DomainFunction<T>

const logErrors = trace<typeof df>(
  ({ input, result, output }) => console.log({ input, result, output })
//          ?^ Result<number>
)
```

## New API proposals
IMO I'd go this route.

We could have both inferences if we changed the `trace` API to something like:
```ts
type Trace = <T>(df: DomainFunction<T>) => (cb: TraceCallback<Result<T>>) => DomainFunction<T>
// or even this to keep same parameter order
type Trace = <T>(cb: TraceCallback<Result<T>>, df: DomainFunction<T>) => DomainFunction<T>
```

What do you think? We could bump the minor to 1.6 and deprecate the 1.5 package maybe.