### PR TITLE
Simplify Unpack types

### DIFF
--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -14,10 +14,11 @@ import type {
   MergeObjs,
   Result,
   TupleToUnion,
+  UnpackAll,
   UnpackData,
   UnpackResult,
 } from './types.ts'
-import type { Last, List, ListToResultData } from './types.ts'
+import type { Last } from './types.ts'
 import type { SuccessResult } from './types.ts'
 
 function makeDomainFunction<
@@ -98,7 +99,7 @@ function makeDomainFunction<
 
 function all<Fns extends DomainFunction[]>(
   ...fns: Fns
-): DomainFunction<List.Map<ListToResultData, Fns>> {
+): DomainFunction<UnpackAll<Fns>> {
   return async (input, environment) => {
     const results = await Promise.all(
       fns.map((fn) => (fn as DomainFunction)(input, environment)),
@@ -121,13 +122,13 @@ function all<Fns extends DomainFunction[]>(
       inputErrors: [],
       environmentErrors: [],
       errors: [],
-    } as SuccessResult<List.Map<ListToResultData, Fns>>
+    } as SuccessResult<UnpackAll<Fns>>
   }
 }
 
 function first<Fns extends DomainFunction[]>(
   ...fns: Fns
-): DomainFunction<TupleToUnion<List.Map<ListToResultData, Fns>>> {
+): DomainFunction<TupleToUnion<UnpackAll<Fns>>> {
   return async (input, environment) => {
     const results = await Promise.all(
       fns.map((fn) => (fn as DomainFunction)(input, environment)),
@@ -141,7 +142,7 @@ function first<Fns extends DomainFunction[]>(
         inputErrors: [],
         environmentErrors: [],
         errors: [],
-      } as SuccessResult<TupleToUnion<List.Map<ListToResultData, Fns>>>
+      } as SuccessResult<TupleToUnion<UnpackAll<Fns>>>
     }
 
     return {
@@ -157,7 +158,7 @@ function first<Fns extends DomainFunction[]>(
 
 function merge<Fns extends DomainFunction[]>(
   ...fns: Fns
-): DomainFunction<MergeObjs<List.Map<ListToResultData, Fns>>> {
+): DomainFunction<MergeObjs<UnpackAll<Fns>>> {
   return async (input, environment) => {
     const results = await Promise.all(
       fns.map((fn) => (fn as DomainFunction)(input, environment)),
@@ -194,7 +195,7 @@ function merge<Fns extends DomainFunction[]>(
       inputErrors: [],
       environmentErrors: [],
       errors: [],
-    } as SuccessResult<MergeObjs<List.Map<ListToResultData, Fns>>>
+    } as SuccessResult<MergeObjs<UnpackAll<Fns>>>
   }
 }
 
@@ -215,7 +216,7 @@ function pipe<T extends DomainFunction[]>(...fns: T): Last<T> {
 
 function sequence<Fns extends DomainFunction[]>(
   ...fns: Fns
-): DomainFunction<List.Map<ListToResultData, Fns>> {
+): DomainFunction<UnpackAll<Fns>> {
   return async function (input: unknown, environment?: unknown) {
     const results = []
     let currResult: undefined | Result<unknown>
@@ -235,7 +236,7 @@ function sequence<Fns extends DomainFunction[]>(
       inputErrors: [],
       environmentErrors: [],
       errors: [],
-    } as SuccessResult<List.Map<ListToResultData, Fns>>
+    } as SuccessResult<UnpackAll<Fns>>
   }
 }
 

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -78,14 +78,11 @@ namespace AtLeastOne {
   const error2: Result = { a: 1, c: 3 }
 }
 
-namespace ListToResultData {
+namespace UnpackAll {
   const dfA = makeDomainFunction()(async () => ({ a: 1 } as const))
   const dfB = makeDomainFunction()(async () => ({ b: 2 } as const))
 
-  type Result = Subject.List.Map<
-    Subject.ListToResultData,
-    [typeof dfA, typeof dfB]
-  >
+  type Result = Subject.UnpackAll<[typeof dfA, typeof dfB]>
 
   type test = Expect<Equal<Result, [{ readonly a: 1 }, { readonly b: 2 }]>>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,11 +30,17 @@ type DomainFunction<Output = unknown> = {
 }
 
 type UnpackResult<F extends DomainFunction> = Awaited<ReturnType<F>>
+
 type UnpackSuccess<F extends DomainFunction> = Extract<
   UnpackResult<F>,
   { success: true }
 >
+
 type UnpackData<F extends DomainFunction> = UnpackSuccess<F>['data']
+
+type UnpackAll<List> = List extends [DomainFunction<infer first>, ...infer rest]
+  ? [first, ...UnpackAll<rest>]
+  : []
 
 type MergeObjs<Objs extends unknown[]> = Objs extends [
   infer First,
@@ -43,40 +49,7 @@ type MergeObjs<Objs extends unknown[]> = Objs extends [
   ? First & MergeObjs<Rest>
   : {}
 
-namespace List {
-  type PopList<T extends unknown[]> = T extends [...infer R, unknown] ? R : T
-  type PopItem<T extends unknown[]> = T extends [...unknown[], infer A]
-    ? A
-    : unknown
-  type IntMapItem<L extends unknown[], M extends Mapper> = M & {
-    Value: PopItem<L>
-    Index: PopList<L>['length']
-  }
-  type IntMapList<
-    MapToType extends Mapper,
-    ListItems extends unknown[],
-    Collected extends unknown[] = [],
-  > = ListItems['length'] extends 0
-    ? Collected
-    : IntMapList<
-        MapToType,
-        PopList<ListItems>,
-        [IntMapItem<ListItems, MapToType>['Return'], ...Collected]
-      >
-
-  export type Mapper<I = unknown, O = unknown> = {
-    Index: number
-    Value: I
-    Return: O
-  }
-  export type Map<M extends Mapper, L extends unknown[]> = IntMapList<M, L, []>
-}
-
-interface ListToResultData extends List.Mapper<DomainFunction> {
-  Return: UnpackData<this['Value']>
-}
-
-type TupleToUnion<T extends any[]> = T[number]
+type TupleToUnion<T extends unknown[]> = T[number]
 
 type Last<T extends readonly unknown[]> = T extends [...infer _I, infer L]
   ? L
@@ -91,13 +64,12 @@ export type {
   ErrorResult,
   ErrorWithMessage,
   Last,
-  List,
-  ListToResultData,
   MergeObjs,
   Result,
   SchemaError,
   SuccessResult,
   TupleToUnion,
+  UnpackAll,
   UnpackData,
   UnpackResult,
   UnpackSuccess,

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,16 +38,19 @@ type UnpackSuccess<F extends DomainFunction> = Extract<
 
 type UnpackData<F extends DomainFunction> = UnpackSuccess<F>['data']
 
-type UnpackAll<List> = List extends [DomainFunction<infer first>, ...infer rest]
-  ? [first, ...UnpackAll<rest>]
-  : []
-
-type MergeObjs<Objs extends unknown[]> = Objs extends [
-  infer First,
-  ...infer Rest,
+type UnpackAll<List, output extends unknown[] = []> = List extends [
+  DomainFunction<infer first>,
+  ...infer rest,
 ]
-  ? First & MergeObjs<Rest>
-  : {}
+  ? UnpackAll<rest, [...output, first]>
+  : output
+
+type MergeObjs<Objs extends unknown[], output = {}> = Objs extends [
+  infer first,
+  ...infer rest,
+]
+  ? MergeObjs<rest, output & first>
+  : output
 
 type TupleToUnion<T extends unknown[]> = T[number]
 


### PR DESCRIPTION
## Purpose

I found a new way to map over a list in TS. It reduces a lot of the complexity I introduced to the `types.ts` file earlier and makes that file more approachable.

## Tech details
Now that we have type tests (#58) it gets easier to refactor at type level 🤤

I also changed some types to use [Tail recursion elimination](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#tail-recursion-elimination-on-conditional-types) which might improve TS perf.

## Concerns
The `List` and `ListToResultData` types along with all the nested types in `List` were "leaking" to the public API even though we didn't document them. It can be [seen here](https://deno.land/x/domain_functions@v1.5.0/mod.ts).

I think and hope no one used it but if they did we are introducing a type level breaking change.

I don't feel like bumping the major but not sure what we should do here... maybe leave those types as deprecated?

This got me to think we should stop doing:
```ts
// ./src/index.ts
export * from './types.ts'
```

Maybe we can have a separate file for public types:
```ts
// ./src/public-types.ts
export { Cherry, Picked, Types } from './types.ts'
```

So we export all of them from the `index.ts`:
```ts
// ./src/index.ts
export * from './public-types.ts'
```

What do you think?